### PR TITLE
fixed bugs with results

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
 
+  # def after_sign_in_path_for(resource)
+  #   stored_location_for(resource) || parameter_path(@parameter)
+  # end
+
   def after_sign_out_path_for(_resource_or_scope)
     root_path
   end

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -7,6 +7,7 @@ class BookingsController < ApplicationController
     trip = FakeData.find(params[:booking][:fake_data_id])
     @booking.user = current_user
     @booking.fake_data = trip
+    trip.toggle!(:booked)
 
     if @booking.save
       redirect_to booking_path(@booking)

--- a/app/controllers/parameters_controller.rb
+++ b/app/controllers/parameters_controller.rb
@@ -1,16 +1,38 @@
 class ParametersController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:new, :create]
+  skip_before_action :authenticate_user!, only: [:new, :create, :show]
   before_action :set_params, only: [:create]
 
   def show
+    FakeData.where('booked != true').destroy_all
+    Parameter.where('id != ?', params[:id]).destroy_all
     # FakeData.destroy_all
     @booking = Booking.new
     @parameter = Parameter.find(params[:id])
     FakeData.generate_results(@parameter)
-    @fastest = FakeData.all.min_by(&:duration)
-    @cheapest = FakeData.all.min_by(&:cost)
 
-    @recommended = FakeData.find(recommended(FakeData.all, @parameter.preferred_start).first)
+    valid_data = FakeData.where("cost != 0 AND booked != true AND end_time < ? AND start_time > ?", @parameter.latest_finish, @parameter.earliest_start)
+
+    if valid_data.all.count.zero?
+      @fastest = @cheapest = @recommended = FakeData.create!(
+        origin: "No Journeys Found",
+        destination: "",
+        cost: 69,
+        start_time: DateTime.new(2069,4,20,4,20,0),
+        end_time: DateTime.new(2069,4,20,16,20,0),
+        duration: 69,
+        mode: "train"
+      )
+    else
+      @fastest = valid_data.min_by(&:duration)
+      @cheapest = valid_data.min_by(&:cost)
+      if valid_data.where(cost: @cheapest.cost).length >= 1
+        @cheapest = valid_data.find(recommended(valid_data.where(cost: @cheapest.cost), @parameter.preferred_start).first)
+      end
+      if valid_data.where(duration: @fastest.duration).length >= 1
+        @fastest = valid_data.find(recommended(valid_data.where(duration: @fastest.duration), @parameter.preferred_start).first)
+      end
+      @recommended = valid_data.find(recommended(valid_data.all, @parameter.preferred_start).first)
+    end
 
     @markers = []
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <link rel="shortcut icon" type="image/jpg" href="../../assets/images/logo_mini.png"/>
+    <link rel="shortcut icon" type="image/jpg" href="/Users/Alex/code/shakey343/ABCheap/app/assets/images/logo_mini.png"/>
+
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/db/migrate/20220307001626_add_booked_to_fake_data.rb
+++ b/db/migrate/20220307001626_add_booked_to_fake_data.rb
@@ -1,0 +1,5 @@
+class AddBookedToFakeData < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fake_data, :booked, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_03_153406) do
+ActiveRecord::Schema.define(version: 2022_03_07_001626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2022_03_03_153406) do
     t.string "mode"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "booked", default: false
   end
 
   create_table "parameters", force: :cascade do |t|


### PR DESCRIPTION
Fully booked train journeys no longer show up as free journeys, everything no longer breaks if there are no megabus and/or train journeys for the parameters, the way fastest and cheapest options are chosen has been updated to account for when there are multiple cheapest or fastest options. 'booked' attribute added to FakeData table which is updated to true for a fakedata instance that is added to a booking. New searches now delete all previous FakeData instances except ones that have been booked. Parameter instances are now also all deleted each time a new search is created. I tried to change the log in to only be required when making a booking, but there is now a bug where you are returned to the search page when you log in instead of completing the booking, unsure how to fix this.